### PR TITLE
Switch default model to gpt-4o-mini-transcribe

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::Config;
 
 const TRANSCRIPTION_ENDPOINT: &str = "https://api.openai.com/v1/audio/transcriptions";
-const DEFAULT_MODEL: &str = "gpt-4o-transcribe";
+const DEFAULT_MODEL: &str = "gpt-4o-mini-transcribe";
 
 #[derive(Debug, Serialize, Clone)]
 struct TranscriptionRequest {


### PR DESCRIPTION
On January 13th, OpenAI is updating the mini-transcribe backend to a newer version. The accuracy is good enough, and it's much cheaper and faster, making it the better default for new users.